### PR TITLE
Swift 4

### DIFF
--- a/Source/UsergridAsset.swift
+++ b/Source/UsergridAsset.swift
@@ -47,7 +47,7 @@ Unless defined, whenever possible, the content-type will be inferred from the da
 */
 public class UsergridAsset: NSObject, NSCoding {
 
-    internal static let DEFAULT_FILE_NAME = "file"
+    public static let DEFAULT_FILE_NAME = "file"
 
     // MARK: - Instance Properties -
 

--- a/Source/UsergridEntity.swift
+++ b/Source/UsergridEntity.swift
@@ -89,7 +89,7 @@ open class UsergridEntity: NSObject, NSCoding {
     public var jsonObjectValue : [String:Any] { return self.properties }
 
     /// The string value.
-    public var stringValue : String { return NSString(data: try! JSONSerialization.data(withJSONObject: self.jsonObjectValue, options: .prettyPrinted), encoding: String.Encoding.utf8.rawValue) as! String }
+    public var stringValue : String { return NSString(data: try! JSONSerialization.data(withJSONObject: self.jsonObjectValue, options: .prettyPrinted), encoding: String.Encoding.utf8.rawValue)! as String }
 
     /// The description.
     open override var description : String {

--- a/Source/UsergridRequestManager.swift
+++ b/Source/UsergridRequestManager.swift
@@ -106,10 +106,10 @@ extension UsergridRequestManager {
                     }
                 }
                 if createdUser == nil {
-                    responseError = UsergridResponseError(jsonDictionary: jsonDict) ?? UsergridResponseError(errorName: "Auth Failed.", errorDescription: "Error Description: \(error?.localizedDescription).")
+                    responseError = UsergridResponseError(jsonDictionary: jsonDict) ?? UsergridResponseError(errorName: "Auth Failed.", errorDescription: "Error Description: \(error?.localizedDescription ?? "").")
                 }
             } else {
-                responseError = UsergridResponseError(errorName: "Auth Failed.", errorDescription: "Error Description: \(error?.localizedDescription).")
+                responseError = UsergridResponseError(errorName: "Auth Failed.", errorDescription: "Error Description: \(error?.localizedDescription ?? "").")
             }
 
             DispatchQueue.main.async {
@@ -129,7 +129,7 @@ extension UsergridRequestManager {
                 appAuth.accessToken = tokenAndExpiry.token
                 appAuth.expiry = tokenAndExpiry.expiry
             } else {
-                responseError = UsergridResponseError(errorName: "Auth Failed.", errorDescription: "Error Description: \(error?.localizedDescription).")
+                responseError = UsergridResponseError(errorName: "Auth Failed.", errorDescription: "Error Description: \(error?.localizedDescription ?? "").")
             }
 
             DispatchQueue.main.async {

--- a/Source/UsergridResponse.swift
+++ b/Source/UsergridResponse.swift
@@ -96,8 +96,8 @@ public class UsergridResponse: NSObject {
 
     /// The string value.
     public var stringValue : String {
-        if let responseJSON = self.responseJSON {
-            return NSString(data: try! JSONSerialization.data(withJSONObject: responseJSON, options: .prettyPrinted), encoding: String.Encoding.utf8.rawValue) as? String ?? ""
+        if let responseJSON = self.responseJSON, let string = NSString(data: try! JSONSerialization.data(withJSONObject: responseJSON, options: .prettyPrinted), encoding: String.Encoding.utf8.rawValue) as String? {
+            return string
         } else {
             return error?.description ?? ""
         }

--- a/Source/UsergridResponseError.swift
+++ b/Source/UsergridResponseError.swift
@@ -42,12 +42,12 @@ public class UsergridResponseError: NSObject {
 
     /// The description.
     public override var description : String {
-        return "Error Name: \(errorName).  Error Description: \(errorDescription).  Exception: \(exception)."
+        return "Error Name: \(errorName).  Error Description: \(errorDescription).  Exception: \(exception ?? "")."
     }
 
     /// The debug description.
     public override var debugDescription : String {
-        return "Error Name: \(errorName).  Error Description: \(errorDescription).  Exception: \(exception)."
+        return "Error Name: \(errorName).  Error Description: \(errorDescription).  Exception: \(exception ?? "")."
     }
 
     // MARK: - Initialization -

--- a/Source/UsergridSessionDelegate.swift
+++ b/Source/UsergridSessionDelegate.swift
@@ -49,7 +49,7 @@ extension UsergridSessionDelegate : URLSessionTaskDelegate {
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         if let requestWrapper = requestDelegates[task.taskIdentifier] {
-            requestWrapper.error = error as? NSError // WTF
+            requestWrapper.error = error as NSError? // WTF
             requestWrapper.completion(requestWrapper)
         }
         self.removeRequestDelegate(task)

--- a/Tests/ASSET_Tests.swift
+++ b/Tests/ASSET_Tests.swift
@@ -48,7 +48,7 @@ class ASSET_Tests: XCTestCase {
     }
 
     func getFullPathOfFile(_ fileLocation:String) -> String {
-        return (Bundle(for: object_getClass(self)).resourcePath!) + "/\(fileLocation)"
+        return (Bundle(for: object_getClass(self)!).resourcePath!) + "/\(fileLocation)"
     }
 
     func test_ASSET_INIT() {

--- a/Tests/ASSET_Tests.swift
+++ b/Tests/ASSET_Tests.swift
@@ -143,7 +143,7 @@ class ASSET_Tests: XCTestCase {
             XCTAssertTrue(removeResponse.ok)
             XCTAssertNotNil(removeResponse.user)
             XCTAssertNotNil(removeResponse.users)
-            print(removeResponse.error)
+            print(removeResponse.error ?? "No error.")
             expectation.fulfill()
         }
     }

--- a/Tests/User_Tests.swift
+++ b/Tests/User_Tests.swift
@@ -163,7 +163,7 @@ class User_Tests: XCTestCase {
             XCTAssertTrue(removeResponse.ok)
             XCTAssertNotNil(removeResponse.user)
             XCTAssertNotNil(removeResponse.users)
-            print(removeResponse.error)
+            print(removeResponse.error ?? "No error.")
             expectation.fulfill()
         }
     }

--- a/UsergridSDK.xcodeproj/project.pbxproj
+++ b/UsergridSDK.xcodeproj/project.pbxproj
@@ -507,7 +507,7 @@
 					};
 					630A21B71C49C473008BE87F = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0920;
 					};
 					6319202A1C48436500F99E86 = {
 						LastSwiftMigration = 0800;
@@ -522,7 +522,7 @@
 					};
 					63AF0E871BBC38FB009D4196 = {
 						CreatedOnToolsVersion = 7.0.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0920;
 					};
 					63EE60F11C406E1600AFC2CF = {
 						LastSwiftMigration = 0800;
@@ -816,7 +816,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.usergrid.swift-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -829,7 +830,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.usergrid.swift-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -1063,7 +1065,8 @@
 				PRODUCT_NAME = UsergridSDK;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1084,7 +1087,8 @@
 				PRODUCT_NAME = UsergridSDK;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/UsergridSDK.xcodeproj/project.pbxproj
+++ b/UsergridSDK.xcodeproj/project.pbxproj
@@ -788,7 +788,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.usergrid.swift-OSX-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -804,7 +803,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -816,8 +814,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.usergrid.swift-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -830,8 +826,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.usergrid.swift-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -856,7 +850,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -881,7 +874,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -893,7 +885,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.apache.usergrid.swift-TVOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
@@ -908,7 +899,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
@@ -929,7 +919,6 @@
 				PRODUCT_NAME = UsergridSDK;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.1;
 			};
@@ -951,7 +940,6 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.1;
 			};
@@ -1000,6 +988,8 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1041,6 +1031,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1065,8 +1057,6 @@
 				PRODUCT_NAME = UsergridSDK;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1087,8 +1077,6 @@
 				PRODUCT_NAME = UsergridSDK;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -1109,7 +1097,6 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -1131,7 +1118,6 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;

--- a/UsergridSDK.xcodeproj/project.pbxproj
+++ b/UsergridSDK.xcodeproj/project.pbxproj
@@ -498,7 +498,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0920;
 				ORGANIZATIONNAME = "Apigee Inc.";
 				TargetAttributes = {
 					630A219E1C49BFFC008BE87F = {
@@ -908,6 +908,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -928,6 +929,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1045,6 +1047,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1065,6 +1068,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1084,6 +1088,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1105,6 +1110,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK OSX.xcscheme
+++ b/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -56,6 +57,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK iOS.xcscheme
+++ b/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -56,6 +57,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK tvOS.xcscheme
+++ b/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -70,6 +71,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK watchOS.xcscheme
+++ b/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK_OSX_Tests.xcscheme
+++ b/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK_OSX_Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,6 +10,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -30,6 +31,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK_TVOS_Tests.xcscheme
+++ b/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK_TVOS_Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,6 +10,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -30,6 +31,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK_iOS_Tests.xcscheme
+++ b/UsergridSDK.xcodeproj/xcshareddata/xcschemes/UsergridSDK_iOS_Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,6 +10,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -31,6 +32,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
## Migration to Swift 4

- Updated project (build) settings

- Fixed two warnings

- Modified visibility of `DEFAULT_FILE_NAME` to public to allow default arguments in `UsergridAsset.swift`
